### PR TITLE
Correct behavior with storyshots

### DIFF
--- a/packages/storycap/src/client/trigger-screenshot.ts
+++ b/packages/storycap/src/client/trigger-screenshot.ts
@@ -75,8 +75,15 @@ function consumeOptions(win: StorycapWindow, storyKey: string): ScreenshotOption
   return result;
 }
 
-function stock(opt: ScreenshotOptions = {}) {
-  const storyKey = url2StoryKey(location.href);
+function stock(opt: ScreenshotOptions = {}, context: any) {
+  let storyKey: string | undefined = undefined;
+
+  if (!!context.kind && !!context.story) {
+    storyKey = context.kind + '/' + context.story;
+  } else {
+    storyKey = url2StoryKey(location.href);
+  }
+
   withExpoesdWindow(win => pushOptions(win, storyKey, opt));
 }
 
@@ -141,9 +148,9 @@ function capture() {
  * @param screenshotOptions - Options for screenshot
  *
  */
-export function triggerScreenshot(screenshotOptions: ScreenshotOptions) {
+export function triggerScreenshot(screenshotOptions: ScreenshotOptions, context: any) {
   // This function can be called twice or more.
   // So we should stock all options for each calling and emit merged them to Node.js
-  stock(screenshotOptions);
+  stock(screenshotOptions, context);
   Promise.resolve().then(capture);
 }

--- a/packages/storycap/src/client/trigger-screenshot.ts
+++ b/packages/storycap/src/client/trigger-screenshot.ts
@@ -78,7 +78,7 @@ function consumeOptions(win: StorycapWindow, storyKey: string): ScreenshotOption
 function stock(opt: ScreenshotOptions = {}, context: any) {
   let storyKey: string | undefined = undefined;
 
-  if (!!context.kind && !!context.story) {
+  if (context && !!context.kind && !!context.story) {
     storyKey = context.kind + '/' + context.story;
   } else {
     storyKey = url2StoryKey(location.href);

--- a/packages/storycap/src/client/trigger-screenshot.ts
+++ b/packages/storycap/src/client/trigger-screenshot.ts
@@ -78,7 +78,9 @@ function consumeOptions(win: StorycapWindow, storyKey: string): ScreenshotOption
 function stock(opt: ScreenshotOptions = {}, context: any) {
   let storyKey: string | undefined = undefined;
 
-  if (context && !!context.kind && !!context.story) {
+  if (context && context.id) {
+    storyKey = context.id;
+  } else if (context && !!context.story && !!context.kind) {
     storyKey = context.kind + '/' + context.story;
   } else {
     storyKey = url2StoryKey(location.href);

--- a/packages/storycap/src/client/with-screenshot.ts
+++ b/packages/storycap/src/client/with-screenshot.ts
@@ -24,7 +24,7 @@ const withScreenshotDecorator =
     allowDeprecatedUsage: true,
     wrapper: (getStory, context, { parameters, options }) => {
       const screenshotOptions = parameters || options;
-      triggerScreenshot(screenshotOptions);
+      triggerScreenshot(screenshotOptions, context);
       return getStory(context);
     },
   });
@@ -32,7 +32,7 @@ const withScreenshotDecorator =
 function withScreenshotLegacy(screenshotOptions: ScreenshotOptions = {}) {
   return (storyFn: Function, ctx: StoryKind | undefined) => {
     const wrapperWithContext = (context: any) => {
-      triggerScreenshot(screenshotOptions);
+      triggerScreenshot(screenshotOptions, context);
       return storyFn(context);
     };
 


### PR DESCRIPTION
At the moment there is an issue with storyshots. I get the following exception (line numbers can differ because it was from my local version with some extra log messages):

|         return kind + "/" + story;
      76 |     }
    > 77 |     throw new Error();
         |           ^
      78 | }
      79 | function waitForDelayTime(time) {
      80 |     if (time === void 0) { time = 0; }

      at url2StoryKey (../../itcb/storycap/packages/storycap/lib/client/trigger-screenshot.js:77:11)
      at url2StoryKey (../../itcb/storycap/packages/storycap/lib/client/trigger-screenshot.js:126:16)
      at Object.stock [as triggerScreenshot] (../../itcb/storycap/packages/storycap/lib/client/trigger-screenshot.js:200:5)
      at triggerScreenshot (../../itcb/storycap/packages/storycap/lib/client/with-screenshot.js:16:34)
      at ../../itcb/storycap/packages/storycap/node_modules/@storybook/addons/dist/make-decorator.js:37:14
      at ../../itcb/storycap/packages/storycap/node_modules/@storybook/addons/dist/make-decorator.js:61:46
      at node_modules/@storybook/client-api/node_modules/@storybook/addons/dist/hooks.js:238:21
      at node_modules/@storybook/client-api/dist/client_api.js:129:14
      at node_modules/@storybook/client-api/dist/client_api.js:130:16
      at withSubscriptionTracking (node_modules/@storybook/client-api/dist/client_api.js:158:16)
      at node_modules/@storybook/client-api/node_modules/@storybook/addons/dist/hooks.js:238:21
      at node_modules/@storybook/client-api/dist/client_api.js:129:14
      at node_modules/@storybook/client-api/node_modules/@storybook/addons/dist/hooks.js:266:20
      at Object.storyFn (node_modules/@storybook/client-api/dist/story_store.js:363:30)
      at getRenderedTree (node_modules/@storybook/addon-storyshots/dist/frameworks/react/renderTree.js:22:30)
      at node_modules/@storybook/addon-storyshots/dist/test-bodies.js:21:18
      at Object.<anonymous> (node_modules/@storybook/addon-storyshots/dist/api/snapshotsTestsTemplate.js:44:33)

For fixing this problem, I now read story and kind out of the context.