### PR TITLE
Fix a screenshot bug when using hover & focus state at the same story

### DIFF
--- a/examples/v5-managed-react/src/stories/index.js
+++ b/examples/v5-managed-react/src/stories/index.js
@@ -1,20 +1,15 @@
 import React from 'react';
-
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
-
 import { Button, Welcome } from '@storybook/react/demo';
-
+import { isScreenshot } from 'storycap';
 import MyButton from '../MyButton';
 import MyInputText from '../MyInputText';
 import ImageButton from '../ImageButton';
 
-import { isScreenshot } from 'storycap';
-
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
-storiesOf('Welcome_override', module)
-.add('to Storybook', () => <Welcome showApp={linkTo('Button')} />, {
+storiesOf('Welcome_override', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />, {
   screenshot: {
     viewport: 'iPhone 6',
     variants: {
@@ -26,7 +21,7 @@ storiesOf('Welcome_override', module)
 });
 
 storiesOf('Button', module)
-  .add('with text', () => <Button onClick={action('clicked')}>Hello { isScreenshot() ? 'Storycap' : 'Button'}</Button>)
+  .add('with text', () => <Button onClick={action('clicked')}>Hello {isScreenshot() ? 'Storycap' : 'Button'}</Button>)
   .add('with some emoji', () => (
     <Button onClick={action('clicked')}>
       <span role="img" aria-label="so cool">
@@ -41,25 +36,27 @@ storiesOf('Button_to_be_skipped', module)
       skip: true,
     },
   })
-  .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
+  .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>);
 
-storiesOf('MyInputText', module)
-  .add('default', () => <MyInputText />, {
-    screenshot: {
-      focus: 'input[type="text"]',
-    },
-  });
+storiesOf('MyInputText', module).add('default', () => <MyInputText />, {
+  screenshot: {
+    focus: 'input[type="text"]',
+  },
+});
 
-storiesOf('MyButton', module)
-  .add('default', () => <MyButton />, {
-    screenshot: {
-      variants: {
-        hover: {
-          extends: ['LARGE', 'SMALL'],
-          hover: '.my-button',
-        },
+storiesOf('MyButton', module).add('default', () => <MyButton />, {
+  screenshot: {
+    variants: {
+      hovered: {
+        extends: ['LARGE', 'SMALL'],
+        hover: '.my-button',
+      },
+      focused: {
+        extends: ['LARGE', 'SMALL'],
+        focus: '.my-button',
       },
     },
-  });
+  },
+});
 
-storiesOf('ImageButton', module).add('default', () => <ImageButton />)
+storiesOf('ImageButton', module).add('default', () => <ImageButton />);

--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -112,7 +112,13 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     if (!this.touched || !story) return;
     this.debug('Reset story because page state got dirty in this request.', this.currentRequestId);
     await this.setCurrentStory(story, { forceRerender: true });
+
+    // Clear the browser state.
+    await this.page.hover('body');
+    await this.page.focus('body');
+
     this.touched = false;
+
     return;
   }
 


### PR DESCRIPTION
## Step to reproduce

- Set hover & focus variants in the story ([source](#)).
- Run `$ ./e2e.sh examples/v5-managed-react`.
- By trying several times, We can look hover state in the focused screenshot image.

## Background

I'm guessing that it bugs related to virtual DOM behavior :bulb:

Storybook is a single page application. So, there is a possibility that the same DOM is used in the surrounding stories.

In the case of a Story with hover and focus states, I think that the next state of the screenshot would retain the previous state. So, there will be cases where the Hover state will remain in the screenshot you tried to take in the Focus state.

## What I did

I added emulate the logic of browser behavior to `CapturingBrowser#resetIfTouched` method (reset states process).

```typescript
// Clear the browser state.
await this.page.hover('body');
await this.page.focus('body');
```

The above code is clear the hovered & focused states in the previous story.

## Screenshots

| Actual | Expect |
|:--|:--|
| ![actual](https://user-images.githubusercontent.com/5393238/72221353-3eebcd80-359d-11ea-901f-c1f8d5c891d0.png) | ![expect](https://user-images.githubusercontent.com/5393238/72221854-c3404f80-35a1-11ea-98b2-51767922c97d.png) |

I tried to about 30 times e2e test on my local environment :dog:
As a result, That bug can't be reproduced.