### PR TITLE
fix typo: emitCatpture -> emitCapture

### DIFF
--- a/packages/storycap/src/client/is-screenshot.ts
+++ b/packages/storycap/src/client/is-screenshot.ts
@@ -4,5 +4,5 @@
  *
  **/
 export function isScreenshot() {
-  return !!(window as any).emitCatpture;
+  return !!(window as any).emitCapture;
 }

--- a/packages/storycap/src/client/trigger-screenshot.ts
+++ b/packages/storycap/src/client/trigger-screenshot.ts
@@ -20,7 +20,7 @@ type StorycapWindow = typeof window & {
 function withExpoesdWindow(cb: (win: StorycapWindow) => any) {
   if (typeof 'window' === 'undefined') return;
   const win = window as StorycapWindow;
-  if (!win.emitCatpture) return;
+  if (!win.emitCapture) return;
   return cb(win);
 }
 
@@ -128,7 +128,7 @@ function capture() {
     const scOpt = pickupWithVariantKey(mergedOptions, variantKey);
 
     // Emit canceling to the main process if `skip: true` and exit this function.
-    if (scOpt.skip) return win.emitCatpture(scOpt, storyKey);
+    if (scOpt.skip) return win.emitCapture(scOpt, storyKey);
 
     // Wait for the following:
     // - Delay time set by options(API or CLI)
@@ -139,7 +139,7 @@ function capture() {
     await waitForNextIdle(win);
 
     // Finally, send options to the Node.js main process.
-    await win.emitCatpture(scOpt, storyKey);
+    await win.emitCapture(scOpt, storyKey);
   });
 }
 

--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -93,7 +93,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
 
   private async expose() {
     const exposed: Exposed = {
-      emitCatpture: (opt: ScreenshotOptions, clientStoryKey: string) =>
+      emitCapture: (opt: ScreenshotOptions, clientStoryKey: string) =>
         this.subscribeScreenshotOptions(opt, clientStoryKey),
       getBaseScreenshotOptions: () => this.baseScreenshotOptions,
       getCurrentVariantKey: () => this.currentVariantKey,

--- a/packages/storycap/src/shared/types.ts
+++ b/packages/storycap/src/shared/types.ts
@@ -63,7 +63,7 @@ export type VariantKey = {
 };
 
 export interface Exposed {
-  emitCatpture(opt: ScreenshotOptions, clientStoryKey: string): void;
+  emitCapture(opt: ScreenshotOptions, clientStoryKey: string): void;
   getBaseScreenshotOptions(): StrictScreenshotOptions;
   getCurrentVariantKey(): VariantKey;
   waitBrowserMetricsStable(): Promise<void>;


### PR DESCRIPTION
I think it has some typos of `capture`.

`emitCatpture` -> `emitCapture`