### PR TITLE
add 'click' to screenshot options

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ interface ScreenshotOptions {
   fullPage?: boolean;                       // default true
   hover?: string;                           // default ""
   focus?: string;                           // default ""
+  click?: string;                           // default ""
   skip?: boolean;                           // default false
   viewport?: Viewport;
   viewports?: string[] | { [variantName]: Viewport };
@@ -233,6 +234,7 @@ interface ScreenshotOptions {
 - `fullPage`: If set true, Storycap captures the entire page of stories.
 - `focus`: If set a valid CSS selector string, Storycap captures after focusing the element matched by the selector.
 - `hover`: If set a valid CSS selector string, Storycap captures after hovering the element matched by the selector.
+- `click`: If set a valid CSS selector string, Storycap captures after clicking the element matched by the selector.
 - `skip`: If set true, Storycap cancels capturing corresponding stories.
 - `viewport`, `viewports`: See type `Viewport` section below.
 - `variants`: See type `Variants` section below.
@@ -252,6 +254,7 @@ type Variants = {
     fullPage?: boolean;
     hover?: string;
     focus?: string;
+    click?: string;
     skip?: boolean;
     viewport?: Viewport;
     waitImages?: boolean;

--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -123,6 +123,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     // Clear the browser state.
     await this.page.hover('body');
     await this.page.focus('body');
+    await this.page.click('body');
 
     this.touched = false;
 
@@ -279,6 +280,14 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     return;
   }
 
+  private async setClick(screenshotOptions: StrictScreenshotOptions) {
+    if (!screenshotOptions.click) return;
+    await this.warnIfTargetElementNotFound(screenshotOptions.click);
+    await this.page.click(screenshotOptions.click);
+    this.touched = true;
+    return;
+  }
+
   private async waitForResources(screenshotOptions: StrictScreenshotOptions) {
     if (!screenshotOptions.waitAssets && !screenshotOptions.waitImages) return;
     this.debug('Wait for requested resources resolved', this.resourceWatcher.getRequestedUrls());
@@ -380,6 +389,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     // Modify elements state.
     await this.setHover(mergedScreenshotOptions);
     await this.setFocus(mergedScreenshotOptions);
+    await this.setClick(mergedScreenshotOptions);
     await this.waitIfTouched();
 
     // Wait until browser main thread gets stable.

--- a/packages/storycap/src/shared/screenshot-options-helper.ts
+++ b/packages/storycap/src/shared/screenshot-options-helper.ts
@@ -8,6 +8,7 @@ const defaultScreenshotOptions = {
   skip: false,
   focus: '',
   hover: '',
+  click: '',
   variants: {},
 } as const;
 

--- a/packages/storycap/src/shared/types.ts
+++ b/packages/storycap/src/shared/types.ts
@@ -20,6 +20,7 @@ export interface ScreenshotOptionFragments {
   fullPage?: boolean;
   hover?: string;
   focus?: string;
+  click?: string;
   skip?: boolean;
 }
 


### PR DESCRIPTION
I've added the screenshot option 'click', which accepts a selector-string (same as 'hover' and 'focus').
It enables you to take screenshots of clicked elements.

This will be very useful, e.g. to capture dropdown-menus after they were expanded.