### PR TITLE
feat: added omitBackground option

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ interface ScreenshotOptions {
   viewports?: string[] | { [variantName]: Viewport };
   variants?: Variants;
   waitImages?: boolean;                     // default true
+  omitBackground?: boolean;                 // default false
 }
 ```
 
@@ -237,6 +238,7 @@ interface ScreenshotOptions {
 - `viewport`, `viewports`: See type `Viewport` section below.
 - `variants`: See type `Variants` section below.
 - `waitImages`: Deprecated. Use `waitAssets`. If set true, Storycap waits until `<img>` in the story are loaded.
+- `omitBackground`: If set true, Storycap omits the background of the page allowing for transparent screenshots. Note the storybook theme will need to be transparent as well.
 
 ### type `Variants`
 

--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -391,7 +391,10 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     );
 
     // Get PNG image buffer
-    const buffer = await this.page.screenshot({ fullPage: emittedScreenshotOptions.fullPage });
+    const buffer = await this.page.screenshot({
+      fullPage: emittedScreenshotOptions.fullPage,
+      omitBackground: emittedScreenshotOptions.omitBackground,
+    });
 
     // We should reset elements state(e.g. focusing, hovering) for future screenshot for this story.
     await this.resetIfTouched();

--- a/packages/storycap/src/shared/screenshot-options-helper.ts
+++ b/packages/storycap/src/shared/screenshot-options-helper.ts
@@ -9,6 +9,7 @@ const defaultScreenshotOptions = {
   focus: '',
   hover: '',
   variants: {},
+  omitBackground: false,
 } as const;
 
 /**

--- a/packages/storycap/src/shared/types.ts
+++ b/packages/storycap/src/shared/types.ts
@@ -21,6 +21,7 @@ export interface ScreenshotOptionFragments {
   hover?: string;
   focus?: string;
   skip?: boolean;
+  omitBackground?: boolean;
 }
 
 export interface ScreenshotOptionFragmentsForVariant extends ScreenshotOptionFragments {


### PR DESCRIPTION
This closes #287.

This PR adds an `omitBackground` option that gets passed through to the browser that can be used to take screenshots with a transparent background.