### PR TITLE
fix: Handle timeout for SB store configuring

### DIFF
--- a/packages/storycrawler/src/errors.ts
+++ b/packages/storycrawler/src/errors.ts
@@ -20,6 +20,15 @@ export class NoStoriesError extends Error {
   name = 'NoStoriesError';
 }
 
+export class StoriesTimeoutError extends Error {
+  name = 'StoriesTimeoutError';
+
+  constructor() {
+    super();
+    this.message = `Getting stories was failed. Make sure that your Storybook is rendered correctly.`;
+  }
+}
+
 export class ChromiumNotFoundError extends Error {
   name = 'ChromiumNotFoundError';
 }


### PR DESCRIPTION
The following error was thrown during waiting for SB store configuring stories. 

It because that the `MAX_CONFIGURE_WAIT_COUNT` variable is defined outside the closure of `page.evaulate` argument, so it cannot be referred inside the closure(this function works in not main process but renderer process). 

```
error Evaluation failed: ReferenceError: MAX_CONFIGURE_WAIT_COUNT is not defined
    at getStories (__puppeteer_evaluation_script__:7:52)
    at __puppeteer_evaluation_script__:23:17
    at new Promise (<anonymous>)
    at __puppeteer_evaluation_script__:1:8
```