### PR TITLE
feat: add captureBeyondViewport option to SnapshotOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ interface ScreenshotOptions {
   variants?: Variants;
   waitImages?: boolean;                     // default true
   omitBackground?: boolean;                 // default false
+  captureBeyondViewport?: boolean;          // default true
 }
 ```
 

--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -402,6 +402,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     const rawBuffer = await this.page.screenshot({
       fullPage: emittedScreenshotOptions.fullPage,
       omitBackground: emittedScreenshotOptions.omitBackground,
+      captureBeyondViewport: emittedScreenshotOptions.captureBeyondViewport,
     });
 
     let buffer: Buffer | null = null;

--- a/packages/storycap/src/shared/screenshot-options-helper.ts
+++ b/packages/storycap/src/shared/screenshot-options-helper.ts
@@ -11,6 +11,7 @@ const defaultScreenshotOptions = {
   click: '',
   variants: {},
   omitBackground: false,
+  captureBeyondViewport: true,
 } as const;
 
 /**

--- a/packages/storycap/src/shared/types.ts
+++ b/packages/storycap/src/shared/types.ts
@@ -23,6 +23,7 @@ export interface ScreenshotOptionFragments {
   click?: string;
   skip?: boolean;
   omitBackground?: boolean;
+  captureBeyondViewport?: boolean;
 }
 
 export interface ScreenshotOptionFragmentsForVariant extends ScreenshotOptionFragments {


### PR DESCRIPTION
As of puppeteer-core v7.0.0, if the content exceeds the viewport, everything will be captured.

https://github.com/puppeteer/puppeteer/tree/v7.0.0

> ⚠ BREAKING CHANGES
> page.screenshot makes a screenshot with the clip dimensions, not cutting it by the ViewPort size.
> chromium: - page.screenshot cuts screenshot content by the ViewPort size, not ViewPort position.

This change caused screenshots to be taken in a different condition than expected.

In puppeteer-core v9.0.0, the captureBeyondViewport option has been introduced, allowing you to clip at the viewport as in the old behavior.

https://github.com/puppeteer/puppeteer/pull/7063
https://github.com/puppeteer/puppeteer/blob/v13.1.3/docs/api.md#pagescreenshotoptions

> captureBeyondViewport <boolean>
> When true, captures screenshot beyond the viewport.
> When false, falls back to old behaviour, and cuts the screenshot by the viewport size. Defaults to true.

Therefore, I have changed storycap to pass the captureBeyondViewport option too.
