### PR TITLE
chore: remove @types/chalk

### DIFF
--- a/packages/storycrawler/package.json
+++ b/packages/storycrawler/package.json
@@ -44,7 +44,6 @@
     "typescript": "4.6.3"
   },
   "dependencies": {
-    "@types/chalk": "^2.2.0",
     "@types/node": "^16.0.0",
     "@types/wait-on": "^5.0.0",
     "chalk": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,12 +1846,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/chalk@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-2.2.0.tgz#b7f6e446f4511029ee8e3f43075fb5b73fbaa0ba"
-  dependencies:
-    chalk "*"
-
 "@types/cli-progress@^3.8.0":
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.8.0.tgz#f60f6d88ef2d9628876c9e906431ac9f34670975"
@@ -2840,14 +2834,6 @@ caniuse-lite@^1.0.30001286:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-
-chalk@*:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
 
 chalk@4.1.0, chalk@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
cf: https://github.com/reg-viz/storycap/pull/211

simply remove @types/chalk because this is not needed.

```
npm WARN deprecated @types/chalk@2.2.0: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
```