### PR TITLE
Upgrade Puppeteer to fix #563

### DIFF
--- a/packages/storycap/package.json
+++ b/packages/storycap/package.json
@@ -68,7 +68,7 @@
     "@types/yargs": "^16.0.0",
     "minimatch": "^3.0.4",
     "mkdirp": "^1.0.0",
-    "puppeteer-core": "^9.0.0",
+    "puppeteer-core": "^13.4.0",
     "rimraf": "^3.0.0",
     "sanitize-filename": "^1.6.3",
     "storycrawler": "^3.1.7",


### PR DESCRIPTION
This PR updates the version of `puppeteer-core` to 13.4+ in order to fix the issue described in #563 with iframes.

Closes #563.