### PR TITLE
Fix disableCssAnimation bug when using multiple viewports

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "deploy:ci": "lerna run clean && yarn build && lerna publish --yes from-package",
     "deploy:manual": "lerna run clean && yarn build && lerna publish",
     "deploy:pages": "gh-pages -d dist-pages -m \"[ci skip]\"",
+    "linkall": "lerna exec --parallel yarn link",
+    "unlinkall": "lerna exec --parallel --bail=false yarn unlink",
     "postinstall": "husky install"
   },
   "repository": {

--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -109,6 +109,12 @@ export class CapturingBrowser extends StoryPreviewBrowser {
     Object.entries(exposed).forEach(([k, f]) => this.page.exposeFunction(k, f));
   }
 
+  private async reload() {
+    await this.page.reload();
+    await sleep(this.opt.viewportDelay);
+    await this.addStyles();
+  }
+
   private async waitIfTouched() {
     if (!this.touched) return;
     await sleep(this.opt.stateChangeDelay);
@@ -255,7 +261,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
       this.viewport = nextViewport;
       if (willBeReloaded || this.opt.reloadAfterChangeViewport) {
         this.processedStories.delete(this.currentRequestId);
-        await Promise.all([this.page.reload(), this.waitForOptionsFromBrowser()]);
+        await Promise.all([this.reload(), this.waitForOptionsFromBrowser()]);
       } else {
         await sleep(this.opt.viewportDelay);
       }


### PR DESCRIPTION
## What does this change?

The bug occurs when using a viewport with `hasTouch` or `isMobile`, or when a page reload is performed using the `reloadAfterChangeViewport` flag. The `disableCssAnimation` is not enabled for shots taken after a page reload.

I've modified the logic to add an element to disable CSS Animation again on page reload.

## How to reproduce

See [wadackel/storycap-reproduce-viewport-bug](https://github.com/wadackel/storycap-reproduce-viewport-bug).

## Actual Behavior

| `Default_iPad`                      | `Default_iPhone11`                      |
| ----------------------------------- | --------------------------------------- |
| ![](https://raw.githubusercontent.com/wadackel/storycap-reproduce-viewport-bug/main/actual/Test/Default_iPad.png) | ![](https://raw.githubusercontent.com/wadackel/storycap-reproduce-viewport-bug/main/actual/Test/Default_iPhone11.png) |

## Expected Behavior (patched)

| `Default_iPad`                        | `Default_iPhone11`                        |
| ------------------------------------- | ----------------------------------------- |
| ![](https://raw.githubusercontent.com/wadackel/storycap-reproduce-viewport-bug/main/expected/Test/Default_iPad.png) | ![](https://raw.githubusercontent.com/wadackel/storycap-reproduce-viewport-bug/main/expected/Test/Default_iPhone11.png) |

## Notes

In the process of debugging, it was necessary to run `yarn link` for each package included in monorepo.

I've added an npm script to make this easier.