### PR TITLE
ci(renovate): automerge non-breaking minor updates, update lockfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["config:base"]
+  "automerge": true,
+  "automergeType": "branch",
+  "extends": ["config:base"],
+  "lockFileMaintenance": { "enabled": true },
+  "major": {
+    "automerge": false
+  }
 }


### PR DESCRIPTION
I'd recommend having non-breaking minor updates automatically added to the main branch. That lessens maintenance work on all those frequent PRs!
You'd only be having a PR for major releases or releases that break the build pipeline.