### PR TITLE
Added additional query for single case

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Options:
       --chromiumPath               Executable Chromium path.                                      [string] [default: ""]
       --puppeteerLaunchConfig      JSON string of launch config for Puppeteer.
                [string] [default: "{ "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"] }"]
+      --additionalQuery, --aq      Additional query string for extra setting specific story       [string] [default: ""]
 
 Examples:
   storycap http://localshot:9009
@@ -381,6 +382,8 @@ Examples:
   storycap http://localshot:9009 -i "some-kind/a-story"
   storycap http://example.com/your-storybook -e "**/default" -V iPad
   storycap --serverCmd "start-storybook -p 3000" http://localshot:3000
+  storycap http://localshot:9009 -aq "knobs-primary=true&knobs-show-lines=true" -i "Global/Components/CodeBlock/Code
+  Block Story"
 
 ```
 

--- a/packages/storycap/src/node/cli.ts
+++ b/packages/storycap/src/node/cli.ts
@@ -84,11 +84,21 @@ function createOptions(): MainOptions {
       default: '{ "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"] }',
       description: 'JSON string of launch config for Puppeteer.',
     })
+    .options('additionalQuery', {
+      string: true,
+      default: '',
+      description: 'Additional query string for extra setting specific story',
+      alias: 'aq',
+    })
     .example('storycap http://localshot:9009', '')
     .example('storycap http://localshot:9009 -V 1024x768 -V 320x568', '')
     .example('storycap http://localshot:9009 -i "some-kind/a-story"', '')
     .example('storycap http://example.com/your-storybook -e "**/default" -V iPad', '')
-    .example('storycap --serverCmd "start-storybook -p 3000" http://localshot:3000', '');
+    .example('storycap --serverCmd "start-storybook -p 3000" http://localshot:3000', '')
+    .example(
+      'storycap http://localshot:9009 -aq "knobs-primary=true&knobs-show-lines=true" -i "Global/Components/CodeBlock/Code Block Story"',
+      '',
+    );
   let storybookUrl;
 
   if (!setting.argv._.length) {

--- a/packages/storycrawler/src/browser/base-browser.ts
+++ b/packages/storycrawler/src/browser/base-browser.ts
@@ -31,10 +31,17 @@ export interface BaseBrowserOptions {
 
   /**
    *
-   * User defind Chromium execuatable binary path
+   * User defined Chromium executable binary path
    *
    **/
   chromiumPath?: string;
+
+  /**
+   *
+   * User defined additional setting query for example knobs
+   *
+   **/
+  additionalQuery?: string;
 }
 
 /**

--- a/packages/storycrawler/src/browser/story-preview-browser.ts
+++ b/packages/storycrawler/src/browser/story-preview-browser.ts
@@ -50,10 +50,16 @@ export class StoryPreviewBrowser extends BaseBrowser {
    **/
   async boot() {
     await super.boot();
-    await this.page.goto(this.connection.url + '/iframe.html?selectedKind=scszisui&selectedStory=scszisui', {
-      timeout: 60_000,
-      waitUntil: 'domcontentloaded',
-    });
+    await this.page.goto(
+      this.connection.url +
+        '/iframe.html?selectedKind=scszisui&selectedStory=scszisui&' +
+        (this.opt.additionalQuery || ''),
+      {
+        timeout: 60_000,
+        waitUntil: 'domcontentloaded',
+      },
+    );
+
     return this;
   }
 


### PR DESCRIPTION
- What to solve
It is very common to use storybook's knobs addon for storybook component nowadays. The screenshot results can vary depending on how to set knobs, example: background: blue or red.
Also, they are set as query strings in browser or puppeteer. Currently, the package doesn't support to set specific knobs.
- Solution
Additional query param has been added in this commit to cli interface and StorybookPreviewBrowser to go to specific version of story
- Note
It has to be used for one specific story. Otherwise, it will be appended to other stories when trying to get all the screenshots.