### PR TITLE
Use named export of @storybook/addons

### DIFF
--- a/packages/storycap/decl/storybook.d.ts
+++ b/packages/storycap/decl/storybook.d.ts
@@ -35,6 +35,5 @@ declare module '@storybook/addons' {
   // Storybook v4 does not export makeDecorator function.
   export const makeDecorator: MakeDecorator | undefined;
 
-  const addons: Addons;
-  export default addons;
+  export const addons: Addons;
 }

--- a/packages/storycap/src/client/register.ts
+++ b/packages/storycap/src/client/register.ts
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/addons';
 
 (window as any).__STORYCAP_MANAGED_MODE_REGISTERED__ = true;
 


### PR DESCRIPTION
Hi,
In storybook v7, default export of `@storybook/addons` will be removed.
https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-more-default-export-from-storybookaddons

When I run storycap in 7.0.0-alpha.26, I got this error. This PR would fix it.
```
register.js:8 Uncaught TypeError: addons_1.default.register is not a function
    at node_modules/storycap/lib/client/register.js (register.js:8:18)
    at __require (register.mjs:9:50)
    at node_modules/storycap/register.js (register.js:1:18)
    at __require (register.mjs:9:50)
    at register.js:1:18
node_modules/storycap/lib/client/register.js @ register.js:8
__require @ register.mjs:9
node_modules/storycap/register.js @ register.js:1
__require @ register.mjs:9
（匿名） @ register.js:1
```
