### PR TITLE
bug: Fixed exposeFunction not being awaited

### DIFF
--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -106,7 +106,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
       getCurrentVariantKey: () => this.currentVariantKey,
       waitBrowserMetricsStable: () => this.waitBrowserMetricsStable('preEmit'),
     };
-    Object.entries(exposed).forEach(([k, f]) => this.page.exposeFunction(k, f));
+    await Promise.all(Object.entries(exposed).map(([k, f]) => this.page.exposeFunction(k, f)));
   }
 
   private async reload() {


### PR DESCRIPTION
`exposeFunction` should be awaited as per [the docs](https://pptr.dev/api/puppeteer.page.exposefunction/)

Closes https://github.com/reg-viz/storycap/issues/631