### PR TITLE
fix: solve a problem with warnings during test execution

### DIFF
--- a/packages/storycap/package.json
+++ b/packages/storycap/package.json
@@ -99,7 +99,7 @@
       "js"
     ],
     "transform": {
-      "^.+\\.ts$": [
+      "^.+\\.tsx?$": [
         "ts-jest",
         {
           "diagnostics": false

--- a/packages/storycap/package.json
+++ b/packages/storycap/package.json
@@ -117,6 +117,8 @@
       "\\.d\\.ts$",
       "lib/.*"
     ],
-    "testURL": "http://localhost"
+    "testEnvironmentOptions": {
+      "url": "http://localhost"
+    }
   }
 }

--- a/packages/storycap/package.json
+++ b/packages/storycap/package.json
@@ -93,18 +93,18 @@
     "yargs": "^16.0.0"
   },
   "jest": {
-    "globals": {
-      "ts-jest": {
-        "diagnostics": false
-      }
-    },
     "moduleFileExtensions": [
       "ts",
       "tsx",
       "js"
     ],
     "transform": {
-      "^.+\\.ts$": "ts-jest"
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "diagnostics": false
+        }
+      ]
     },
     "testMatch": [
       "**/__tests__/*.(ts|tsx)",

--- a/packages/storycrawler/package.json
+++ b/packages/storycrawler/package.json
@@ -60,7 +60,7 @@
       "js"
     ],
     "transform": {
-      "^.+\\.ts$": [
+      "^.+\\.tsx?$": [
         "ts-jest",
         {
           "diagnostics": false

--- a/packages/storycrawler/package.json
+++ b/packages/storycrawler/package.json
@@ -54,18 +54,18 @@
     "wait-on": "^7.0.0"
   },
   "jest": {
-    "globals": {
-      "ts-jest": {
-        "diagnostics": false
-      }
-    },
     "moduleFileExtensions": [
       "ts",
       "tsx",
       "js"
     ],
     "transform": {
-      "^.+\\.ts$": "ts-jest"
+      "^.+\\.ts$": [
+        "ts-jest",
+        {
+          "diagnostics": false
+        }
+      ]
     },
     "testMatch": [
       "**/__tests__/*.(ts|tsx)",


### PR DESCRIPTION
When I ran the test, there were several warnings, so I changed the settings for each of them.
Please see the commit message for details.

- fix(test): replace testURL options to testEnvironmentOptions.url
- fix(jest): replace ts-jest config to transform
- fix(jest): added files with .tsx extension to the transform target
