### PR TITLE
fix typo: localshot -> localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,11 +382,11 @@ Options:
                [string] [default: "{ "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"] }"]
 
 Examples:
-  storycap http://localshot:9009
-  storycap http://localshot:9009 -V 1024x768 -V 320x568
-  storycap http://localshot:9009 -i "some-kind/a-story"
+  storycap http://localhost:9009
+  storycap http://localhost:9009 -V 1024x768 -V 320x568
+  storycap http://localhost:9009 -i "some-kind/a-story"
   storycap http://example.com/your-storybook -e "**/default" -V iPad
-  storycap --serverCmd "start-storybook -p 3000" http://localshot:3000
+  storycap --serverCmd "start-storybook -p 3000" http://localhost:3000
 
 ```
 

--- a/packages/storycap/src/node/cli.ts
+++ b/packages/storycap/src/node/cli.ts
@@ -91,11 +91,11 @@ function createOptions(): MainOptions {
       default: '{ "args": ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"] }',
       description: 'JSON string of launch config for Puppeteer.',
     })
-    .example('storycap http://localshot:9009', '')
-    .example('storycap http://localshot:9009 -V 1024x768 -V 320x568', '')
-    .example('storycap http://localshot:9009 -i "some-kind/a-story"', '')
+    .example('storycap http://localhost:9009', '')
+    .example('storycap http://localhost:9009 -V 1024x768 -V 320x568', '')
+    .example('storycap http://localhost:9009 -i "some-kind/a-story"', '')
     .example('storycap http://example.com/your-storybook -e "**/default" -V iPad', '')
-    .example('storycap --serverCmd "start-storybook -p 3000" http://localshot:3000', '');
+    .example('storycap --serverCmd "start-storybook -p 3000" http://localhost:3000', '');
   let storybookUrl;
 
   if (!setting.argv._.length) {


### PR DESCRIPTION
I think it is a typo.

`shot` → `host`