### PR TITLE
chore: Use fs promises for filesystem APIs

### DIFF
--- a/packages/storycap/src/node/file.ts
+++ b/packages/storycap/src/node/file.ts
@@ -1,6 +1,5 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import path from 'path';
-import * as mkdirp from 'mkdirp';
 import { MainOptions } from './types';
 import sanitize from 'sanitize-filename';
 
@@ -18,7 +17,7 @@ export class FileSystem {
    * @returns Absolute file path
    *
    **/
-  save(kind: string, story: string, suffix: string[], buffer: Buffer) {
+  async save(kind: string, story: string, suffix: string[], buffer: Buffer) {
     const name = this.opt.flat
       ? sanitize((kind + '_' + story).replace(/\//g, '_'))
       : kind
@@ -28,12 +27,10 @@ export class FileSystem {
         '/' +
         sanitize(story);
     const filePath = path.join(this.opt.outDir, name + (suffix.length ? `_${suffix.join('_')}` : '') + '.png');
-    return new Promise<string>((resolve, reject) => {
-      mkdirp.sync(path.dirname(filePath));
-      fs.writeFile(filePath, buffer, err => {
-        if (err) reject(err);
-        resolve(filePath);
-      });
-    });
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, buffer);
+
+    return filePath;
   }
 }


### PR DESCRIPTION
This PR refactors the FileSystem class to use `fs/promises` (available since Node 10) for all filesystem operations, instead of synchronously building folders with mkdirp, and re-building a promise to write the file.