### PR TITLE
Forward console logs from the story context to the user's CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Options:
       --disableWaitAssets          Disable waiting for requested assets                       [boolean] [default: false]
       --silent                                                                                [boolean] [default: false]
       --verbose                                                                               [boolean] [default: false]
+      --forwardConsoleLogs                                                                    [boolean] [default: false]
       --serverCmd                  Command line to launch Storybook server.                       [string] [default: ""]
       --serverTimeout              Timeout [msec] for starting Storybook server.               [number] [default: 60000]
       --shard                      The sharding options for this run. In the format <shardNumber>/<totalShards>.

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Options:
       --disableWaitAssets          Disable waiting for requested assets                       [boolean] [default: false]
       --silent                                                                                [boolean] [default: false]
       --verbose                                                                               [boolean] [default: false]
-      --forwardConsoleLogs                                                                    [boolean] [default: false]
+      --forwardConsoleLogs         Forward in-page console logs to the user's console.        [boolean] [default: false]
       --serverCmd                  Command line to launch Storybook server.                       [string] [default: ""]
       --serverTimeout              Timeout [msec] for starting Storybook server.               [number] [default: 60000]
       --shard                      The sharding options for this run. In the format <shardNumber>/<totalShards>.

--- a/packages/storycap/src/node/cli.ts
+++ b/packages/storycap/src/node/cli.ts
@@ -36,7 +36,11 @@ function createOptions(): MainOptions {
     })
     .option('silent', { boolean: true, default: false })
     .option('verbose', { boolean: true, default: false })
-    .option('forwardConsoleLogs', { boolean: true, default: false })
+    .option('forwardConsoleLogs', {
+      boolean: true,
+      default: false,
+      description: "Forward in-page console logs to the user's console.",
+    })
     .option('serverCmd', { string: true, default: '', description: 'Command line to launch Storybook server.' })
     .option('serverTimeout', {
       number: true,

--- a/packages/storycap/src/node/cli.ts
+++ b/packages/storycap/src/node/cli.ts
@@ -36,6 +36,7 @@ function createOptions(): MainOptions {
     })
     .option('silent', { boolean: true, default: false })
     .option('verbose', { boolean: true, default: false })
+    .option('forwardConsoleLogs', { boolean: true, default: false })
     .option('serverCmd', { string: true, default: '', description: 'Command line to launch Storybook server.' })
     .option('serverTimeout', {
       number: true,
@@ -114,6 +115,7 @@ function createOptions(): MainOptions {
     parallel,
     silent,
     verbose,
+    forwardConsoleLogs,
     serverTimeout,
     serverCmd,
     shard,
@@ -179,6 +181,7 @@ function createOptions(): MainOptions {
     stateChangeDelay,
     disableCssAnimation,
     disableWaitAssets,
+    forwardConsoleLogs,
     chromiumChannel: chromiumChannel as ChromeChannel,
     chromiumPath,
     launchOptions: puppeteerLaunchConfig,

--- a/packages/storycap/src/node/main.ts
+++ b/packages/storycap/src/node/main.ts
@@ -93,7 +93,13 @@ export async function main(mainOptions: MainOptions) {
 
   try {
     // Execution caputuring procedure.
-    const captured = await createScreenshotService({ workers, stories: shardedStories, fileSystem, logger }).execute();
+    const captured = await createScreenshotService({
+      workers,
+      stories: shardedStories,
+      fileSystem,
+      logger,
+      forwardConsoleLogs: mainOptions.forwardConsoleLogs,
+    }).execute();
     logger.debug('Ended ScreenshotService execution.');
     return captured;
   } catch (error) {

--- a/packages/storycap/src/node/screenshot-service.ts
+++ b/packages/storycap/src/node/screenshot-service.ts
@@ -48,6 +48,7 @@ export type ScreenshotServiceOptions = {
   workers: CapturingBrowser[];
   fileSystem: FileSystem;
   stories: Story[];
+  forwardConsoleLogs: boolean;
 };
 
 /**
@@ -63,6 +64,7 @@ export function createScreenshotService({
   logger,
   stories,
   workers,
+  forwardConsoleLogs,
 }: ScreenshotServiceOptions): ScreenshotService {
   const service = createExecutionService(
     workers,
@@ -70,7 +72,9 @@ export function createScreenshotService({
     ({ rid, story, variantKey, count }, { push }) =>
       async worker => {
         // Delegate the request to the worker.
-        const [result, elapsedTime] = await time(worker.screenshot(rid, story, variantKey, count));
+        const [result, elapsedTime] = await time(
+          worker.screenshot(rid, story, variantKey, count, logger, forwardConsoleLogs),
+        );
 
         const { succeeded, buffer, variantKeysToPush, defaultVariantSuffix } = result;
 

--- a/packages/storycap/src/node/types.ts
+++ b/packages/storycap/src/node/types.ts
@@ -40,6 +40,7 @@ export interface MainOptions extends BaseBrowserOptions {
   exclude: string[];
   disableCssAnimation: boolean;
   disableWaitAssets: boolean;
+  forwardConsoleLogs: boolean;
   parallel: number;
   shard: ShardOptions;
   metricsWatchRetryCount: number;

--- a/packages/storycap/src/shared/screenshot-options-helper.ts
+++ b/packages/storycap/src/shared/screenshot-options-helper.ts
@@ -13,6 +13,7 @@ const defaultScreenshotOptions = {
   omitBackground: false,
   captureBeyondViewport: true,
   clip: null,
+  forwardConsoleLogs: false,
 } as const;
 
 /**


### PR DESCRIPTION
This builds on https://github.com/reg-viz/storycap/pull/789, happy to rebase as needed.

Currently the screenshot utility swallows all console logs and errors from the 'story' context. This makes debugging screenshots extremely difficult. (It's also quite difficult to mount a debugger to the internal story isolate.)

This PR forwards console messages by default into the `debug` Logger channel, and optionally allows for a `--forwardConsoleLogs` option to surface them to the user's CLI with matched `error`, `warn` or `info` log levels.

Messages currently look like:

`error From examples-thrusttestbench--screenshot-light (error): THREE.WebGLRenderer: Error creating WebGL context.`

![image](https://github.com/reg-viz/storycap/assets/13504878/a238f0a3-4f22-418b-bb09-130e49730ece)

Happy to bikeshed the cli option name, format of the logs, etc.
