### PR TITLE
Record CPU traces from screenshot runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Options:
   -V, --viewport                   Viewport.                                              [array] [default: ["800x600"]]
       --disableCssAnimation        Disable CSS animation and transition.                       [boolean] [default: true]
       --disableWaitAssets          Disable waiting for requested assets                       [boolean] [default: false]
+      --trace                      Emit Chromium trace files per screenshot.                  [boolean] [default: false]
       --silent                                                                                [boolean] [default: false]
       --verbose                                                                               [boolean] [default: false]
       --forwardConsoleLogs         Forward in-page console logs to the user's console.        [boolean] [default: false]

--- a/packages/storycap/src/node/cli.ts
+++ b/packages/storycap/src/node/cli.ts
@@ -34,6 +34,7 @@ function createOptions(): MainOptions {
       default: false,
       description: 'Disable waiting for requested assets',
     })
+    .option('trace', { boolean: true, default: false, description: 'Emit Chromium trace files per screenshot.' })
     .option('silent', { boolean: true, default: false })
     .option('verbose', { boolean: true, default: false })
     .option('forwardConsoleLogs', {
@@ -131,6 +132,7 @@ function createOptions(): MainOptions {
     stateChangeDelay,
     disableCssAnimation,
     disableWaitAssets,
+    trace,
     listDevices,
     chromiumChannel,
     chromiumPath,
@@ -185,6 +187,7 @@ function createOptions(): MainOptions {
     stateChangeDelay,
     disableCssAnimation,
     disableWaitAssets,
+    trace,
     forwardConsoleLogs,
     chromiumChannel: chromiumChannel as ChromeChannel,
     chromiumPath,

--- a/packages/storycap/src/node/file.ts
+++ b/packages/storycap/src/node/file.ts
@@ -6,6 +6,20 @@ import sanitize from 'sanitize-filename';
 export class FileSystem {
   constructor(private opt: MainOptions) {}
 
+  private getPath(kind: string, story: string, suffix: string[], extension: string) {
+    const name = this.opt.flat
+      ? sanitize((kind + '_' + story).replace(/\//g, '_'))
+      : kind
+          .split('/')
+          .map(k => sanitize(k))
+          .join('/') +
+        '/' +
+        sanitize(story);
+    const filePath = path.join(this.opt.outDir, name + (suffix.length ? `_${suffix.join('_')}` : '') + extension);
+
+    return filePath;
+  }
+
   /**
    *
    * Save captured buffer as a PNG image.
@@ -17,16 +31,28 @@ export class FileSystem {
    * @returns Absolute file path
    *
    **/
-  async save(kind: string, story: string, suffix: string[], buffer: Buffer) {
-    const name = this.opt.flat
-      ? sanitize((kind + '_' + story).replace(/\//g, '_'))
-      : kind
-          .split('/')
-          .map(k => sanitize(k))
-          .join('/') +
-        '/' +
-        sanitize(story);
-    const filePath = path.join(this.opt.outDir, name + (suffix.length ? `_${suffix.join('_')}` : '') + '.png');
+  async saveScreenshot(kind: string, story: string, suffix: string[], buffer: Buffer) {
+    const filePath = this.getPath(kind, story, suffix, '.png');
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, buffer);
+
+    return filePath;
+  }
+
+  /**
+   *
+   * Save captured tracing buffer as a json file.
+   *
+   * @param kind - Story kind
+   * @param story - Name of this story
+   * @param suffix - File name suffix
+   * @param buffer - PNG image buffer to save
+   * @returns Absolute file path
+   *
+   **/
+  async saveTrace(kind: string, story: string, suffix: string[], buffer: Buffer) {
+    const filePath = this.getPath(kind, story, [...suffix, 'trace'], '.json');
 
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, buffer);

--- a/packages/storycap/src/node/main.ts
+++ b/packages/storycap/src/node/main.ts
@@ -99,6 +99,7 @@ export async function main(mainOptions: MainOptions) {
       fileSystem,
       logger,
       forwardConsoleLogs: mainOptions.forwardConsoleLogs,
+      trace: mainOptions.trace,
     }).execute();
     logger.debug('Ended ScreenshotService execution.');
     return captured;

--- a/packages/storycap/src/node/screenshot-service.ts
+++ b/packages/storycap/src/node/screenshot-service.ts
@@ -49,6 +49,7 @@ export type ScreenshotServiceOptions = {
   fileSystem: FileSystem;
   stories: Story[];
   forwardConsoleLogs: boolean;
+  trace: boolean;
 };
 
 /**
@@ -65,6 +66,7 @@ export function createScreenshotService({
   stories,
   workers,
   forwardConsoleLogs,
+  trace,
 }: ScreenshotServiceOptions): ScreenshotService {
   const service = createExecutionService(
     workers,
@@ -73,7 +75,7 @@ export function createScreenshotService({
       async worker => {
         // Delegate the request to the worker.
         const [result, elapsedTime] = await time(
-          worker.screenshot(rid, story, variantKey, count, logger, forwardConsoleLogs),
+          worker.screenshot(rid, story, variantKey, count, logger, forwardConsoleLogs, trace, fileSystem),
         );
 
         const { succeeded, buffer, variantKeysToPush, defaultVariantSuffix } = result;
@@ -87,7 +89,7 @@ export function createScreenshotService({
 
         if (buffer) {
           const suffix = variantKey.isDefault && defaultVariantSuffix ? [defaultVariantSuffix] : variantKey.keys;
-          const path = await fileSystem.save(story.kind, story.story, suffix, buffer);
+          const path = await fileSystem.saveScreenshot(story.kind, story.story, suffix, buffer);
           logger.log(`Screenshot stored: ${logger.color.magenta(path)} in ${elapsedTime} msec.`);
           return true;
         }

--- a/packages/storycap/src/node/types.ts
+++ b/packages/storycap/src/node/types.ts
@@ -40,6 +40,7 @@ export interface MainOptions extends BaseBrowserOptions {
   exclude: string[];
   disableCssAnimation: boolean;
   disableWaitAssets: boolean;
+  trace: boolean;
   forwardConsoleLogs: boolean;
   parallel: number;
   shard: ShardOptions;

--- a/packages/storycap/src/shared/screenshot-options-helper.ts
+++ b/packages/storycap/src/shared/screenshot-options-helper.ts
@@ -14,6 +14,7 @@ const defaultScreenshotOptions = {
   captureBeyondViewport: true,
   clip: null,
   forwardConsoleLogs: false,
+  trace: false,
 } as const;
 
 /**


### PR DESCRIPTION
This builds on https://github.com/reg-viz/storycap/pull/790 and https://github.com/reg-viz/storycap/pull/789, happy to rebase as needed.

When debugging performance problems with screenshots, it's helpful to have a flamegraph of what's taking time.

It's difficult to mount a debugger into the internal story isolate. This PR enables a `--trace` cli option that records a Chromium CPU trace of the screenshot and saves it alongside the screenshot `filename.png` as `filename_trace.json`.

This trace can be imported into Chrome's Performance Flamegraph or https://ui.perfetto.dev/ for viewing.

![image](https://github.com/reg-viz/storycap/assets/13504878/143f682d-f55a-4c5a-82fc-ba49fa172817)

This is especially helpful for situations like:

![image](https://github.com/reg-viz/storycap/assets/13504878/2ac445fa-3fab-4b90-ae3d-06420600b2d6)

Despite the screenshot not succeeding, the trace of the last attempt will still be written, and we can plainly see that this particular screenshot continues work forever, never giving the metrics a chance to stabilise:

![image](https://github.com/reg-viz/storycap/assets/13504878/5326b7f6-6ee5-4991-b863-dd6cf7d3244f)