### PR TITLE
Add option to make nocase in include and exclude comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ Options:
   -f, --flat                       Flatten output filename.                                   [boolean] [default: false]
   -i, --include                    Including stories name rule.                                    [array] [default: []]
   -e, --exclude                    Excluding stories name rule.                                    [array] [default: []]
+      --matchNocase                'include' and 'exclude' comparisons to be non case sensitive.
+                                                                                              [boolean] [default: false]
       --delay                      Waiting time [msec] before screenshot for each story.           [number] [default: 0]
   -V, --viewport                   Viewport.                                              [array] [default: ["800x600"]]
       --disableCssAnimation        Disable CSS animation and transition.                       [boolean] [default: true]

--- a/packages/storycap/src/node/cli.ts
+++ b/packages/storycap/src/node/cli.ts
@@ -22,6 +22,11 @@ function createOptions(): MainOptions {
     .option('flat', { boolean: true, alias: 'f', default: false, description: 'Flatten output filename.' })
     .option('include', { array: true, alias: 'i', default: [], description: 'Including stories name rule.' })
     .option('exclude', { array: true, alias: 'e', default: [], description: 'Excluding stories name rule.' })
+    .option('matchNocase', {
+      boolean: true,
+      default: false,
+      description: "'include' and 'exclude' comparisons to be non case sensitive.",
+    })
     .option('delay', { number: true, default: 0, description: 'Waiting time [msec] before screenshot for each story.' })
     .option('viewport', { array: true, alias: 'V', default: ['800x600'], description: 'Viewport.' })
     .option('disableCssAnimation', {
@@ -115,6 +120,7 @@ function createOptions(): MainOptions {
     flat,
     include,
     exclude,
+    matchNocase,
     delay,
     viewport,
     parallel,
@@ -175,6 +181,7 @@ function createOptions(): MainOptions {
     flat,
     include,
     exclude,
+    matchNocase,
     delay,
     viewports: viewport,
     parallel,

--- a/packages/storycap/src/node/types.ts
+++ b/packages/storycap/src/node/types.ts
@@ -38,6 +38,7 @@ export interface MainOptions extends BaseBrowserOptions {
   flat: boolean;
   include: string[];
   exclude: string[];
+  matchNocase: boolean;
   disableCssAnimation: boolean;
   disableWaitAssets: boolean;
   trace: boolean;


### PR DESCRIPTION
There are use cases where I want to ignore upper and lower case letters when comparing Story names.

Storybook corrects the Story name to TitleCase, maybe :). So, there is a pattern that the Story name extracted from the Storybook does not hit well when compared to the Story name.