### PR TITLE
[Feature]  Update Storycap commands for Storybook v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,6 @@ Examples:
   storycap http://example.com/your-storybook -e "**/default" -V iPad
   storycap --serverCmd "start-storybook -p 3000" http://localhost:3000
   storycap --serverCmd "start dev -p 3000" http://localhost:3000 # For storybook v7
-  storycap --serverCmd "start dev -p 3000" http://localhost:3000 # For storybook v7
 ```
 
 <!-- endinject -->

--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ Examples:
   storycap http://localhost:9009 -i "some-kind/a-story"
   storycap http://example.com/your-storybook -e "**/default" -V iPad
   storycap --serverCmd "start-storybook -p 3000" http://localhost:3000
-
+  storycap --serverCmd "start dev -p 3000" http://localhost:3000 # For storybook v7
+  storycap --serverCmd "start dev -p 3000" http://localhost:3000 # For storybook v7
 ```
 
 <!-- endinject -->

--- a/packages/storycap/src/node/cli.ts
+++ b/packages/storycap/src/node/cli.ts
@@ -101,7 +101,8 @@ function createOptions(): MainOptions {
     .example('storycap http://localhost:9009 -V 1024x768 -V 320x568', '')
     .example('storycap http://localhost:9009 -i "some-kind/a-story"', '')
     .example('storycap http://example.com/your-storybook -e "**/default" -V iPad', '')
-    .example('storycap --serverCmd "start-storybook -p 3000" http://localhost:3000', '');
+    .example('storycap --serverCmd "start-storybook -p 3000" http://localhost:3000', '')
+    .example(`storycap --serverCmd "start dev -p 3000" http://localhost:3000 # For storybook v7`, '');
   let storybookUrl;
 
   if (!setting.argv._.length) {


### PR DESCRIPTION
## What does this change?

The name was changed from `start-storybook` to `storybook-dev` starting with storybook v7.
https://storybook.js.org/docs/react/api/cli-options

I have spent a lot of time on CI/CD retrofits due to this change.

This change will help users of storybook v7.

Thank you for your cooperation.   @[hond0413](https://github.com/hond0413)


We need your opinions! Please feel free to comment here. Thank you 🙇

## References

```shell
> storycap --serverTimeout 60000 --captureTimeout 10000 --serverCmd 'start-storybook -p 6006' http://localhost:6006

info Wait for connecting storybook server http://localhost:6006.
error Timed out waiting for: http-get://localhost:6006
Error: Timed out waiting for: http-get://localhost:6006
```

## fix result

```shell
> app@1.0.0 screenshot /
> storycap --serverTimeout 60000 --captureTimeout 10000 --serverCmd 'storybook dev -p 6006' http://localhost:6006

info Wait for connecting storybook server http://localhost:6006.
info Executable Chromium path: /usr/bin/google-chrome-stable
info Storycap runs with managed mode
info Found 3 stories.
info Screenshot was ended successfully in 22285 msec capturing 3 PNGs.
```