### PR TITLE
chore: fix external link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ type Variants = {
 
 ### type `Viewport`
 
-`Viewport` is compatible for [Puppeteer viewport interface](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetviewportviewport).
+`Viewport` is compatible for [Puppeteer viewport interface](https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.viewport.md).
 
 ```ts
 type Viewport =
@@ -309,7 +309,7 @@ type Viewport =
     };
 ```
 
-**Note:** You should choose a valid [device name](https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts) if set string.
+**Note:** You should choose a valid [device name](https://github.com/puppeteer/puppeteer/blob/main/packages/puppeteer-core/src/common/Device.ts) if set string.
 
 `Viewport` values are available in `viewports` field such as:
 

--- a/packages/storycap/src/node/capturing-browser.ts
+++ b/packages/storycap/src/node/capturing-browser.ts
@@ -258,7 +258,7 @@ export class CapturingBrowser extends StoryPreviewBrowser {
       await this.page.setViewport(nextViewport);
 
       // Setting isMobile or hasTouch properties will reload the page.
-      // See also https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagesetviewportviewport
+      // See also https://github.com/puppeteer/puppeteer/blob/main/docs/api/puppeteer.viewport.md
       const willBeReloaded =
         nextViewport.isMobile !== this.viewport?.isMobile || nextViewport.hasTouch !== this.viewport?.hasTouch;
       this.viewport = nextViewport;


### PR DESCRIPTION
## What does this change?

Some links in the README and comment to the puppeteer repository were broken, so I have updated them.

## References

None

## Screenshots

None

## What can I check for bug fixes?

Not Bug