### PR TITLE
Allow disabling nextStep STORYCAP_NEXTSTEP=disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It is primarily responsible for image generation necessary for Visual Testing su
   - [type `Viewport`](#type-viewport)
   - [function `isScreenshot`](#function-isscreenshot)
 - [Command Line Options](#command-line-options)
+- [Environment Variables](#environment-variables)
 - [Multiple PNGs from 1 story](#multiple-pngs-from-1-story)
   - [Basic usage](#basic-usage)
   - [Variants composition](#variants-composition)
@@ -360,6 +361,13 @@ Examples:
 ```
 
 <!-- endinject -->
+
+## Environment Variables
+
+| Name              | Description |
+|:------------------|:------------|
+| STORYCAP_SHOW     | Set to `enabled` to start the browser in the headful mode instead of in the headless one. When using the headful mode, you'll have to execute `nextStep()` on the console to advance from one screenshot to another one. |
+| STORYCAP_NEXTSTEP | Set to `disabled`, if you want to make all screenshots in the headful mode in an unattended way, without advancing by the `nextStep()` execution. |
 
 ## Multiple PNGs from 1 story
 

--- a/packages/storycrawler/src/browser/base-browser.ts
+++ b/packages/storycrawler/src/browser/base-browser.ts
@@ -48,6 +48,7 @@ export abstract class BaseBrowser {
   private _executablePath = '';
   private debugInputResolver = () => {};
   private debugInputPromise: Promise<void> = Promise.resolve();
+  private nextStep = process.env['STORYCAP_NEXTSTEP'] !== 'disabled';
 
   /**
    *
@@ -140,7 +141,7 @@ export abstract class BaseBrowser {
    *
    **/
   protected async waitForDebugInput() {
-    if (this.opt.launchOptions && this.opt.launchOptions.headless === false) {
+    if (this.opt.launchOptions && this.opt.launchOptions.headless === false && this.nextStep) {
       // eslint-disable-next-line no-console
       console.log(
         'story-crawler waits for your input. Open Puppeteer devtool console and exec "nextStep()" to go to the next step.',
@@ -150,7 +151,7 @@ export abstract class BaseBrowser {
   }
 
   private async setupDebugInput() {
-    if (this.opt.launchOptions && this.opt.launchOptions.headless === false) {
+    if (this.opt.launchOptions && this.opt.launchOptions.headless === false && this.nextStep) {
       const resetInput: () => void = () =>
         (this.debugInputPromise = new Promise<void>(res => (this.debugInputResolver = res)).then(() => {
           setTimeout(() => resetInput(), 10);


### PR DESCRIPTION
Set `STORYCAP_NEXTSTEP=disabled`, if you want to make all screenshots in the headful mode in an unattended way, without advancing by the `nextStep()` execution.