### PR TITLE
feat: Allow connection URL with search and hash parts

### DIFF
--- a/packages/storycrawler/src/browser/stories-browser.ts
+++ b/packages/storycrawler/src/browser/stories-browser.ts
@@ -3,7 +3,7 @@ import { Logger } from '../logger';
 import { NoStoriesError, StoriesTimeoutError } from '../errors';
 import { Story } from '../story-types';
 import { StorybookConnection } from '../storybook-connection';
-import { getUrlWithoutSearchAndHash } from '../url-utils';
+import { completeIframeUrl } from '../url-utils';
 
 interface API {
   storyStore?: {
@@ -64,11 +64,14 @@ export class StoriesBrowser extends BaseBrowser {
     await this.page.goto(this.connection.url);
     let stories: Story[] | null = null;
 
-    const baseUrl = getUrlWithoutSearchAndHash(this.connection.url);
+    const iframeUrl = completeIframeUrl(
+      this.connection.url,
+      'iframe.html?selectedKind=story-crawler-kind&selectedStory=story-crawler-story',
+    );
     // Note:
     // Don't wait fo this `goto` promise. Sometimes Chromimue emits timeout error and this navigation and causes whole screenshot process abortion.
     // For detail, see https://github.com/reg-viz/storycap/issues/896#issuecomment-2317248668
-    this.page.goto(baseUrl + '/iframe.html?selectedKind=story-crawler-kind&selectedStory=story-crawler-story');
+    this.page.goto(iframeUrl);
 
     await this.page.waitForFunction(
       () =>

--- a/packages/storycrawler/src/browser/stories-browser.ts
+++ b/packages/storycrawler/src/browser/stories-browser.ts
@@ -3,6 +3,7 @@ import { Logger } from '../logger';
 import { NoStoriesError, StoriesTimeoutError } from '../errors';
 import { Story } from '../story-types';
 import { StorybookConnection } from '../storybook-connection';
+import { getUrlWithoutSearchAndHash } from '../url-utils';
 
 interface API {
   storyStore?: {
@@ -63,12 +64,11 @@ export class StoriesBrowser extends BaseBrowser {
     await this.page.goto(this.connection.url);
     let stories: Story[] | null = null;
 
+    const baseUrl = getUrlWithoutSearchAndHash(this.connection.url);
     // Note:
     // Don't wait fo this `goto` promise. Sometimes Chromimue emits timeout error and this navigation and causes whole screenshot process abortion.
     // For detail, see https://github.com/reg-viz/storycap/issues/896#issuecomment-2317248668
-    this.page.goto(
-      this.connection.url + '/iframe.html?selectedKind=story-crawler-kind&selectedStory=story-crawler-story',
-    );
+    this.page.goto(baseUrl + '/iframe.html?selectedKind=story-crawler-kind&selectedStory=story-crawler-story');
 
     await this.page.waitForFunction(
       () =>

--- a/packages/storycrawler/src/browser/story-preview-browser.ts
+++ b/packages/storycrawler/src/browser/story-preview-browser.ts
@@ -3,7 +3,7 @@ import { Story } from '../story-types';
 import { Logger } from '../logger';
 import { sleep } from '../async-utils';
 import { StorybookConnection } from '../storybook-connection';
-import { getUrlWithoutSearchAndHash } from '../url-utils';
+import { completeIframeUrl } from '../url-utils';
 
 const dummyStory: Story = {
   version: 'v5',
@@ -44,8 +44,11 @@ export class StoryPreviewBrowser extends BaseBrowser {
    **/
   async boot() {
     await super.boot();
-    const baseUrl = getUrlWithoutSearchAndHash(this.connection.url);
-    await this.page.goto(baseUrl + '/iframe.html?selectedKind=scszisui&selectedStory=scszisui', {
+    const iframeUrl = completeIframeUrl(
+      this.connection.url,
+      'iframe.html?selectedKind=scszisui&selectedStory=scszisui',
+    );
+    await this.page.goto(iframeUrl, {
       timeout: 60_000,
       waitUntil: 'domcontentloaded',
     });

--- a/packages/storycrawler/src/browser/story-preview-browser.ts
+++ b/packages/storycrawler/src/browser/story-preview-browser.ts
@@ -3,6 +3,7 @@ import { Story } from '../story-types';
 import { Logger } from '../logger';
 import { sleep } from '../async-utils';
 import { StorybookConnection } from '../storybook-connection';
+import { getUrlWithoutSearchAndHash } from '../url-utils';
 
 const dummyStory: Story = {
   version: 'v5',
@@ -43,7 +44,8 @@ export class StoryPreviewBrowser extends BaseBrowser {
    **/
   async boot() {
     await super.boot();
-    await this.page.goto(this.connection.url + '/iframe.html?selectedKind=scszisui&selectedStory=scszisui', {
+    const baseUrl = getUrlWithoutSearchAndHash(this.connection.url);
+    await this.page.goto(baseUrl + '/iframe.html?selectedKind=scszisui&selectedStory=scszisui', {
       timeout: 60_000,
       waitUntil: 'domcontentloaded',
     });

--- a/packages/storycrawler/src/url-utils.test.ts
+++ b/packages/storycrawler/src/url-utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from '@jest/globals';
+import { completeIframeUrl } from './url-utils';
+
+describe(completeIframeUrl, () => {
+  it('concatenates URLs with no search and hash parts', () => {
+    expect(completeIframeUrl('http://localhost:6006', 'iframe.html')).toEqual('http://localhost:6006/iframe.html');
+  });
+
+  it('appends iframe URL to a URL with a root path', () => {
+    expect(completeIframeUrl('http://localhost:6006/', 'iframe.html')).toEqual('http://localhost:6006/iframe.html');
+  });
+
+  it('appends iframe URL to a URL with a directory path', () => {
+    expect(completeIframeUrl('http://localhost:6006/storybook', 'iframe.html')).toEqual(
+      'http://localhost:6006/storybook/iframe.html',
+    );
+  });
+
+  it('appends iframe URL to a URL with a directory path ending with slash', () => {
+    expect(completeIframeUrl('http://localhost:6006/storybook/', 'iframe.html')).toEqual(
+      'http://localhost:6006/storybook/iframe.html',
+    );
+  });
+
+  it('appends iframe URL with a search part', () => {
+    expect(completeIframeUrl('http://localhost:6006', 'iframe.html?foo=bar')).toEqual(
+      'http://localhost:6006/iframe.html?foo=bar',
+    );
+  });
+
+  it('appends iframe URL with a search part to connection URL with a search part', () => {
+    expect(completeIframeUrl('http://localhost:6006?screenshots', 'iframe.html?foo=bar')).toEqual(
+      'http://localhost:6006/iframe.html?foo=bar&screenshots',
+    );
+  });
+
+  it('appends iframe URL with no search part to connection URL with a search part', () => {
+    expect(completeIframeUrl('http://localhost:6006?screenshots', 'iframe.html')).toEqual(
+      'http://localhost:6006/iframe.html?screenshots',
+    );
+  });
+
+  it('appends iframe URL to connection URL with a hash part', () => {
+    expect(completeIframeUrl('http://localhost:6006#screenshot', 'iframe.html')).toEqual(
+      'http://localhost:6006/iframe.html#screenshot',
+    );
+  });
+
+  it('appends iframe URL to connection URL with search and hash parts', () => {
+    expect(completeIframeUrl('http://localhost:6006?foo=bar#screenshot', 'iframe.html')).toEqual(
+      'http://localhost:6006/iframe.html?foo=bar#screenshot',
+    );
+  });
+});

--- a/packages/storycrawler/src/url-utils.ts
+++ b/packages/storycrawler/src/url-utils.ts
@@ -1,23 +1,31 @@
 /**
  *
- * Cuts search and hash parts of a URL off a URL
+ * Completes the URL to the iframe with stories with `search` and `hash` parts of the connection URL
  *
- * @param url - An absolute URL, optionally with search and hash parts
- * @returns The input URl with the search and hash parts cau off
+ * @param connectionUrl - An absolute URL to the Storybook web site
+ * @param relativeIframeUrl - A relative URL to the iframe with stories
+ * @returns An absolute URL to the iframe with stories with `search` and `hash` parts of the connection URL
  *
  **/
-export function getUrlWithoutSearchAndHash(url: string): string {
-  // Do not use new URL(path, connectionUrl), to concatenate a path to a page to
-  // the connection URL. The URL constructor would cut the last name on the path
-  // as a file to append the new path to the last directory on the original path,
-  // but the original implementation just appended '/iframe.html' to the
-  // connection URL.
-  const urlObject = new URL(url);
-  urlObject.search = '';
-  urlObject.hash = '';
-  let baseUrl = urlObject.toString();
-  if (baseUrl.endsWith('/')) {
-    baseUrl = baseUrl.slice(0, -1);
+export function completeIframeUrl(connectionUrl: string, relativeIframeUrl: string): string {
+  const connectionUrlObject = new URL(connectionUrl);
+  // Treat the connection URL as a URL to a directory, when appending
+  // the relative path to it. The original implementation just appended
+  // '/iframe.html' to the connection URL.
+  if (!connectionUrlObject.pathname.endsWith('/')) {
+    connectionUrlObject.pathname += '/';
   }
-  return baseUrl;
+  const iframeUrlObject = new URL(relativeIframeUrl, connectionUrlObject.href);
+  const { search: iframeSearch } = iframeUrlObject;
+  let { search: connectionSearch } = connectionUrlObject;
+  // Append the search part from the connection URL to the iframe URL
+  if (connectionSearch) {
+    if (iframeSearch) {
+      connectionSearch = '&' + connectionSearch.slice(1);
+    }
+    iframeUrlObject.search += connectionSearch;
+  }
+  // Set the hash part from the connection URL to the iframe URL
+  iframeUrlObject.hash = connectionUrlObject.hash;
+  return iframeUrlObject.href;
 }

--- a/packages/storycrawler/src/url-utils.ts
+++ b/packages/storycrawler/src/url-utils.ts
@@ -1,0 +1,23 @@
+/**
+ *
+ * Cuts search and hash parts of a URL off a URL
+ *
+ * @param url - An absolute URL, optionally with search and hash parts
+ * @returns The input URl with the search and hash parts cau off
+ *
+ **/
+export function getUrlWithoutSearchAndHash(url: string): string {
+  // Do not use new URL(path, connectionUrl), to concatenate a path to a page to
+  // the connection URL. The URL constructor would cut the last name on the path
+  // as a file to append the new path to the last directory on the original path,
+  // but the original implementation just appended '/iframe.html' to the
+  // connection URL.
+  const urlObject = new URL(url);
+  urlObject.search = '';
+  urlObject.hash = '';
+  let baseUrl = urlObject.toString();
+  if (baseUrl.endsWith('/')) {
+    baseUrl = baseUrl.slice(0, -1);
+  }
+  return baseUrl;
+}


### PR DESCRIPTION
Allow passing URL parameters to Storybook. Screenshots can be taken with the stories behaving diffetly by default, for example:

* Enable different visual themes.
* Disable animations.
* Shorten mocked network response timeouts.